### PR TITLE
Fix string comparison in publish script

### DIFF
--- a/src/workflows/publish.sh
+++ b/src/workflows/publish.sh
@@ -37,7 +37,7 @@ if ! git fetch --end-of-options origin "refs/tags/$version_tag" 2>/dev/null; the
 fi
 
 latest_tag="$(git describe --tags --abbrev=0)"
-if ! $version_tag == latest_tag; then
+if ! [ "$version_tag" = "$latest_tag" ]; then
   echo "Latest tag $latest_tag version doesn't match package.json version $version"
   exit 1
 fi


### PR DESCRIPTION
Previous run tried executing `latest_tag` as a command:

<img width="407" alt="image" src="https://user-images.githubusercontent.com/3328006/186516374-ce0cc2dc-8834-4021-900e-d9d149ee2642.png">
