### PR TITLE
Order class to meta data

### DIFF
--- a/src/generatedTypes/index.ts
+++ b/src/generatedTypes/index.ts
@@ -4,21 +4,24 @@ import * as v0_1_0 from './v0.1.0'
 import * as v0_2_0 from './v0.2.0'
 import * as v0_3_0 from './v0.3.0'
 import * as v0_4_0 from './v0.4.0'
+import * as v0_5_0 from './v0.5.0'
 
-export * as latest from './v0.4.0'
+export * as latest from './v0.5.0'
 
-export const LATEST_APP_DATA_VERSION = '0.4.0'
+export const LATEST_APP_DATA_VERSION = '0.5.0'
 export const LATEST_QUOTE_METADATA_VERSION = '0.2.0'
 export const LATEST_REFERRER_METADATA_VERSION = '0.1.0'
 
-export type LatestAppDataDocVersion = v0_4_0.AppDataRootSchema
+export type LatestAppDataDocVersion = v0_5_0.AppDataRootSchema
 export type AnyAppDataDocVersion = 
+  | v0_5_0.AppDataRootSchema
   | v0_4_0.AppDataRootSchema
   | v0_3_0.AppDataRootSchema
   | v0_2_0.AppDataRootSchema
   | v0_1_0.AppDataRootSchema
 
 export {
+  v0_5_0,
   v0_4_0,
   v0_3_0,
   v0_2_0,

--- a/src/generatedTypes/v0.1.0.ts
+++ b/src/generatedTypes/v0.1.0.ts
@@ -6,13 +6,17 @@
  */
 
 /**
- * Semantic versioning of document
+ * Semantic versioning of document.
  */
 export type Version = string;
 /**
  * The code identifying the CLI, UI, service generating the order.
  */
 export type AppCode = string;
+/**
+ * Semantic versioning of document.
+ */
+export type Version1 = string;
 export type ReferrerAddress = string;
 
 /**
@@ -32,7 +36,7 @@ export interface Metadata {
   [k: string]: unknown;
 }
 export interface Referrer {
-  version: Version;
+  version: Version1;
   address: ReferrerAddress;
   [k: string]: unknown;
 }

--- a/src/generatedTypes/v0.2.0.ts
+++ b/src/generatedTypes/v0.2.0.ts
@@ -6,17 +6,25 @@
  */
 
 /**
- * Semantic versioning of document
+ * Semantic versioning of document.
  */
 export type Version = string;
 /**
  * The code identifying the CLI, UI, service generating the order.
  */
 export type AppCode = string;
+/**
+ * Semantic versioning of document.
+ */
+export type Version1 = string;
 export type ReferrerAddress = string;
 export type QuoteId = string;
 export type QuoteSellAmount = string;
 export type QuoteBuyAmount = string;
+/**
+ * Semantic versioning of document.
+ */
+export type Version2 = string;
 
 /**
  * Metadata JSON document for adding information to orders.
@@ -36,7 +44,7 @@ export interface Metadata {
   [k: string]: unknown;
 }
 export interface Referrer {
-  version: Version;
+  version: Version1;
   address: ReferrerAddress;
   [k: string]: unknown;
 }
@@ -44,6 +52,6 @@ export interface Quote {
   id?: QuoteId;
   sellAmount: QuoteSellAmount;
   buyAmount: QuoteBuyAmount;
-  version: Version;
+  version: Version2;
   [k: string]: unknown;
 }

--- a/src/generatedTypes/v0.3.0.ts
+++ b/src/generatedTypes/v0.3.0.ts
@@ -6,7 +6,7 @@
  */
 
 /**
- * Semantic versioning of document
+ * Semantic versioning of document.
  */
 export type Version = string;
 /**
@@ -17,10 +17,18 @@ export type AppCode = string;
  * Environment from which the order came from
  */
 export type Environment = string;
+/**
+ * Semantic versioning of document.
+ */
+export type Version1 = string;
 export type ReferrerAddress = string;
 export type QuoteId = string;
 export type QuoteSellAmount = string;
 export type QuoteBuyAmount = string;
+/**
+ * Semantic versioning of document.
+ */
+export type Version2 = string;
 
 /**
  * Metadata JSON document for adding information to orders.
@@ -41,7 +49,7 @@ export interface Metadata {
   [k: string]: unknown;
 }
 export interface Referrer {
-  version: Version;
+  version: Version1;
   address: ReferrerAddress;
   [k: string]: unknown;
 }
@@ -49,6 +57,6 @@ export interface Quote {
   id?: QuoteId;
   sellAmount: QuoteSellAmount;
   buyAmount: QuoteBuyAmount;
-  version: Version;
+  version: Version2;
   [k: string]: unknown;
 }

--- a/src/generatedTypes/v0.5.0.ts
+++ b/src/generatedTypes/v0.5.0.ts
@@ -30,6 +30,14 @@ export type Version2 = string;
  * Slippage tolerance that was applied to the order to get the limit price. Expressed in Basis Points (BIPS)
  */
 export type SlippageBips = string;
+/**
+ * Semantic versioning of document.
+ */
+export type Version3 = string;
+/**
+ * Indicator of the order class.
+ */
+export type OrderClass1 = "market" | "limit" | "liquidity";
 
 /**
  * Metadata JSON document for adding information to orders.
@@ -47,6 +55,7 @@ export interface AppDataRootSchema {
 export interface Metadata {
   referrer?: Referrer;
   quote?: Quote;
+  orderClass?: OrderClass;
   [k: string]: unknown;
 }
 export interface Referrer {
@@ -57,5 +66,10 @@ export interface Referrer {
 export interface Quote {
   version: Version2;
   slippageBips: SlippageBips;
+  [k: string]: unknown;
+}
+export interface OrderClass {
+  version: Version3;
+  orderClass: OrderClass1;
   [k: string]: unknown;
 }

--- a/src/schemas/definitions.json
+++ b/src/schemas/definitions.json
@@ -6,6 +6,7 @@
     "version": {
       "$id": "#/definitions/version",
       "description": "Semantic versioning of document.",
+      "readOnly": true,
       "examples": [
         "1.0.0",
         "1.2.3"
@@ -30,22 +31,6 @@
         "90741097240912730913, 0, 75891372"
       ],
       "type": "string"
-    },
-    "orderClass": {
-      "$id": "#/definitions/orderClass",
-      "description": "Indicator of the order class.",
-      "examples": [
-        "market",
-        "limit",
-        "liquidity"
-      ],
-      "title": "Order class",
-      "type": "string",
-      "enum": [
-        "market",
-        "limit",
-        "liquidity"
-      ]
     }
   }
 }

--- a/src/schemas/definitions.json
+++ b/src/schemas/definitions.json
@@ -30,6 +30,22 @@
         "90741097240912730913, 0, 75891372"
       ],
       "type": "string"
+    },
+    "orderClass": {
+      "$id": "#/definitions/orderClass",
+      "description": "Indicator of the order class.",
+      "examples": [
+        "market",
+        "limit",
+        "liquidity"
+      ],
+      "title": "Order class",
+      "type": "string",
+      "enum": [
+        "market",
+        "limit",
+        "liquidity"
+      ]
     }
   }
 }

--- a/src/schemas/orderClass/v0.1.0.json
+++ b/src/schemas/orderClass/v0.1.0.json
@@ -14,8 +14,20 @@
       "default": "0.1.0"
     },
     "orderClass": {
-      "$ref": "../definitions.json#/definitions/orderClass",
-      "title": "Order class"
+      "$id": "#/definitions/orderClass",
+      "description": "Indicator of the order class.",
+      "examples": [
+        "market",
+        "limit",
+        "liquidity"
+      ],
+      "title": "Order class",
+      "type": "string",
+      "enum": [
+        "market",
+        "limit",
+        "liquidity"
+      ]
     }
   }
 }

--- a/src/schemas/orderClass/v0.1.0.json
+++ b/src/schemas/orderClass/v0.1.0.json
@@ -1,0 +1,21 @@
+{
+  "$id": "#orderClass/v0.1.0.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "required": [
+    "version",
+    "orderClass"
+  ],
+  "title": "Order class",
+  "type": "object",
+  "properties": {
+    "version": {
+      "$ref": "../definitions.json#/definitions/version",
+      "readOnly": true,
+      "default": "0.1.0"
+    },
+    "orderClass": {
+      "$ref": "../definitions.json#/definitions/orderClass",
+      "title": "Order class"
+    }
+  }
+}

--- a/src/schemas/v0.5.0.json
+++ b/src/schemas/v0.5.0.json
@@ -1,0 +1,58 @@
+{
+  "$id": "https://cowswap.exchange/schemas/app-data/v0.5.0.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "description": "Metadata JSON document for adding information to orders.",
+  "required": [
+    "version",
+    "metadata"
+  ],
+  "title": "AppData Root Schema",
+  "type": "object",
+  "properties": {
+    "version": {
+      "$ref": "definitions.json#/definitions/version",
+      "readOnly": true,
+      "default": "0.5.0"
+    },
+    "appCode": {
+      "$id": "#/properties/appCode",
+      "description": "The code identifying the CLI, UI, service generating the order.",
+      "examples": [
+        "CoW Swap"
+      ],
+      "title": "App Code",
+      "type": "string"
+    },
+    "environment": {
+      "$id": "#/properties/environment",
+      "description": "Environment from which the order came from.",
+      "title": "Environment",
+      "type": "string",
+      "examples": [
+        "production",
+        "development",
+        "staging",
+        "ens"
+      ]
+    },
+    "metadata": {
+      "$id": "#/properties/metadata",
+      "default": {},
+      "description": "Each metadata will specify one aspect of the order.",
+      "required": [],
+      "title": "Metadata",
+      "type": "object",
+      "properties": {
+        "referrer": {
+          "$ref": "referrer/v0.1.0.json#"
+        },
+        "quote": {
+          "$ref": "quote/v0.2.0.json#"
+        },
+        "orderClass": {
+          "$ref": "orderClass/v0.1.0.json#"
+        }
+      }
+    }
+  }
+}

--- a/test/schema.spec.ts
+++ b/test/schema.spec.ts
@@ -204,7 +204,7 @@ describe('Schema v0.5.0', () => {
   const validator = ajv.compile(schemaV0_5_0)
 
   const BASE_DOCUMENT = {
-    version: '0.4.0',
+    version: '0.5.0',
     metadata: {},
   }
 

--- a/test/schema.spec.ts
+++ b/test/schema.spec.ts
@@ -4,9 +4,11 @@ import schemaV0_1_0 from '../schemas/v0.1.0.json'
 import schemaV0_2_0 from '../schemas/v0.2.0.json'
 import schemaV0_3_0 from '../schemas/v0.3.0.json'
 import schemaV0_4_0 from '../schemas/v0.4.0.json'
+import schemaV0_5_0 from '../schemas/v0.5.0.json'
 
 const ADDRESS = '0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9'
 const REFERRER_V0_1_0 = { address: ADDRESS, version: '0.1.0' }
+const ORDER_CLASS_V0_1_0 = { orderClass: 'limit', version: '0.1.0' }
 const QUOTE_V0_1_0 = { sellAmount: '123123', buyAmount: '1314123', version: '0.1.0' }
 const QUOTE_V0_2_0 = { slippageBips: '1', version: '0.2.0' }
 
@@ -191,6 +193,60 @@ describe('Schema v0.4.0', () => {
           message: "must have required property 'slippageBips'",
           params: { missingProperty: 'slippageBips' },
           schemaPath: '#/properties/metadata/properties/quote/required',
+        },
+      ]
+    )
+  )
+})
+
+describe('Schema v0.5.0', () => {
+  const ajv = new Ajv()
+  const validator = ajv.compile(schemaV0_5_0)
+
+  const BASE_DOCUMENT = {
+    version: '0.4.0',
+    metadata: {},
+  }
+
+  test('Minimal valid schema', _buildAssertValidFn(validator, BASE_DOCUMENT))
+
+  test('Missing required fields', _buildAssertInvalidFn(validator, {}, MISSING_VERSION_ERROR))
+
+  test(
+    'With order class v0.1.0',
+    _buildAssertValidFn(validator, {
+      ...BASE_DOCUMENT,
+      appCode: 'MyApp',
+      environment: 'prod',
+      metadata: {
+        referrer: REFERRER_V0_1_0,
+        quote: QUOTE_V0_2_0,
+        orderClass: ORDER_CLASS_V0_1_0,
+      },
+    })
+  )
+
+  test(
+    'With invalid order class v0.1.0',
+    _buildAssertInvalidFn(
+      validator,
+      {
+        ...BASE_DOCUMENT,
+        appCode: 'MyApp',
+        environment: 'prod',
+        metadata: {
+          referrer: REFERRER_V0_1_0,
+          quote: QUOTE_V0_2_0,
+          orderClass: { orderClass: 'mooo', version: '0.1.0' }, // Invalid value
+        },
+      },
+      [
+        {
+          instancePath: '/metadata/orderClass/orderClass',
+          keyword: 'enum',
+          message: 'must be equal to one of the allowed values',
+          params: { allowedValues: ['market', 'limit', 'liquidity'] },
+          schemaPath: '#/properties/metadata/properties/orderClass/properties/orderClass/enum',
         },
       ]
     )


### PR DESCRIPTION
Fixes: https://github.com/cowprotocol/cowswap/issues/1599

For analytics purposes, we need to add the type of order to the `appData`.

The new result:
```
{
  "appCode": "CoW Swap",
  "environment": "local",
  "metadata": {
    "quote": {
      "slippageBips": "0",
      "version": "0.2.0"
    },
    "orderClass": {
      "orderClass": "market",
      "version": "0.1.0"
    }
  },
  "version": "0.5.0"
}
```