### PR TITLE
Fixing default export type. From .cjs to .mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "source": "src/index.ts",
   "exports": {
     "require": "./dist/index.cjs",
-    "default": "./dist/index.modern.cjs"
+    "default": "./dist/index.modern.mjs"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.module.js",


### PR DESCRIPTION
# Summary

Related to https://github.com/cowprotocol/cow-sdk/issues/91
Fixing default export type. 

From `.cjs` to `.mjs`

# Context

* `cjs` defines `CommonJS` modules, used by default on NodeJS (when importing with `require()`)
* `mjs` defines ECMA modlues (when importing with `import` or `import()`)

For a proper explanation see [NodeJS reference](https://nodejs.org/api/packages.html#packages_determining_module_system)

This was a mistake on my part when initially created this lib.
Instead of following [the recommended export from microbundle](https://github.com/developit/microbundle#-modern-mode-) for some reason I used `.cjs` instead.
Don't really recall why.

# Testing

I tested it locally using [yalc](https://github.com/wclr/yalc) and the test app [cow-sdk-app](https://github.com/adamazad/cow-sdk-app) provided in [this issue](https://github.com/cowprotocol/cow-sdk/issues/91)

1. On `app-data` app, publish it with yalc: `yalc publish`
2. On `cow-sdk` app, add the yalc build: `yalc add @cowprocotol/app-data`
3. Run tests on `cow-sdk`: `yarn test`
* Tests should succeed
4. Publish `cow-sdk` with yalc: `yalc publish`
5. On [cow-sdk-app](https://github.com/adamazad/cow-sdk-app), add both libs with yalc: `yalc add @cowprocotol/app-data && yalc add @cowprocotol/cow-sdk`
6. Build the app: `npm run build`
* The build should succeed
7. Start the app: `npm run start`
* It should start (some warnings might be thrown which are unrelated to the apps in question)
