### PR TITLE
fix: add utm when generating app-data doc

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -7,6 +7,7 @@ import {
   createOrderClassMetadata,
   createQuoteMetadata,
   createReferrerMetadata,
+  createUtmMetadata,
   getAppDataSchema,
   validateAppDataDoc,
   ValidationResult,
@@ -41,7 +42,7 @@ export class MetadataApi {
    */
   async generateAppDataDoc(params?: GenerateAppDataDocParams): Promise<LatestAppDataDocVersion> {
     const { appDataParams, metadataParams } = params || {}
-    const { referrerParams, quoteParams, orderClassParams } = metadataParams || {}
+    const { referrerParams, quoteParams, orderClassParams, utmParams } = metadataParams || {}
 
     const metadata: latest.Metadata = {}
     if (referrerParams) {
@@ -52,6 +53,9 @@ export class MetadataApi {
     }
     if (orderClassParams) {
       metadata.orderClass = createOrderClassMetadata(orderClassParams)
+    }
+    if (utmParams) {
+      metadata.utm = createUtmMetadata(utmParams)
     }
 
     const appCode = appDataParams?.appCode || DEFAULT_APP_CODE

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,4 +1,10 @@
-import type { createAppDataDoc, createOrderClassMetadata, createQuoteMetadata, createReferrerMetadata } from '../utils'
+import type {
+  createAppDataDoc,
+  createOrderClassMetadata,
+  createQuoteMetadata,
+  createReferrerMetadata,
+  createUtmMetadata,
+} from '../utils'
 
 export type GenerateAppDataDocParams = {
   appDataParams?: Omit<Parameters<typeof createAppDataDoc>[0], 'metadata'>
@@ -6,6 +12,7 @@ export type GenerateAppDataDocParams = {
     referrerParams?: Parameters<typeof createReferrerMetadata>[0]
     quoteParams?: Parameters<typeof createQuoteMetadata>[0]
     orderClassParams?: Parameters<typeof createOrderClassMetadata>[0]
+    utmParams: Parameters<typeof createUtmMetadata>[0]
   }
 }
 

--- a/src/generatedTypes/index.ts
+++ b/src/generatedTypes/index.ts
@@ -13,9 +13,10 @@ export const LATEST_APP_DATA_VERSION = '0.6.0'
 export const LATEST_QUOTE_METADATA_VERSION = '0.2.0'
 export const LATEST_REFERRER_METADATA_VERSION = '0.1.0'
 export const LATEST_ORDER_CLASS_METADATA_VERSION = '0.1.0'
+export const LATEST_UTM_METADATA_VERSION = '0.1.0'
 
 export type LatestAppDataDocVersion = v0_6_0.AppDataRootSchema
-export type AnyAppDataDocVersion = 
+export type AnyAppDataDocVersion =
   | v0_6_0.AppDataRootSchema
   | v0_5_0.AppDataRootSchema
   | v0_4_0.AppDataRootSchema
@@ -23,11 +24,4 @@ export type AnyAppDataDocVersion =
   | v0_2_0.AppDataRootSchema
   | v0_1_0.AppDataRootSchema
 
-export {
-  v0_6_0,
-  v0_5_0,
-  v0_4_0,
-  v0_3_0,
-  v0_2_0,
-  v0_1_0  
-} 
+export { v0_6_0, v0_5_0, v0_4_0, v0_3_0, v0_2_0, v0_1_0 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,7 @@ import {
   LATEST_ORDER_CLASS_METADATA_VERSION,
   LATEST_QUOTE_METADATA_VERSION,
   LATEST_REFERRER_METADATA_VERSION,
+  LATEST_UTM_METADATA_VERSION,
 } from './generatedTypes'
 
 // TODO: Cannot understand why this doesn't work. TS complains saying the type parameters are unknown
@@ -31,6 +32,13 @@ export function createOrderClassMetadata(params: { orderClass: latest.OrderClass
   return {
     ...params,
     version: LATEST_ORDER_CLASS_METADATA_VERSION,
+  }
+}
+
+export function createUtmMetadata(params: { utm: latest.UTMCodes }): latest.UTMCodes {
+  return {
+    ...params,
+    version: LATEST_UTM_METADATA_VERSION,
   }
 }
 


### PR DESCRIPTION
This PR adds the missing params to the API of the doc generation