### PR TITLE
Format Existing Schemas With `prettier`

### DIFF
--- a/src/schemas/definitions.json
+++ b/src/schemas/definitions.json
@@ -7,10 +7,7 @@
       "$id": "#/definitions/version",
       "description": "Semantic versioning of document.",
       "readOnly": true,
-      "examples": [
-        "1.0.0",
-        "1.2.3"
-      ],
+      "examples": ["1.0.0", "1.2.3"],
       "title": "Version",
       "type": "string"
     },
@@ -18,18 +15,14 @@
       "$id": "#/definitions/ethereumAddress",
       "pattern": "^0x[a-fA-F0-9]{40}$",
       "title": "Ethereum compatible address",
-      "examples": [
-        "0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9"
-      ],
+      "examples": ["0xb6BAd41ae76A11D10f7b0E664C5007b908bC77C9"],
       "type": "string"
     },
     "bigNumber": {
       "$id": "#/definitions/bigNumber",
       "pattern": "^\\d+$",
       "title": "BigNumber",
-      "examples": [
-        "90741097240912730913, 0, 75891372"
-      ],
+      "examples": ["90741097240912730913, 0, 75891372"],
       "type": "string"
     }
   }

--- a/src/schemas/definitions.json
+++ b/src/schemas/definitions.json
@@ -22,7 +22,7 @@
       "$id": "#/definitions/bigNumber",
       "pattern": "^\\d+$",
       "title": "BigNumber",
-      "examples": ["90741097240912730913, 0, 75891372"],
+      "examples": ["90741097240912730913", "0", "75891372"],
       "type": "string"
     }
   }

--- a/src/schemas/orderClass/v0.1.0.json
+++ b/src/schemas/orderClass/v0.1.0.json
@@ -1,10 +1,7 @@
 {
   "$id": "#orderClass/v0.1.0.json",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "required": [
-    "version",
-    "orderClass"
-  ],
+  "required": ["version", "orderClass"],
   "title": "Order class",
   "type": "object",
   "properties": {
@@ -16,18 +13,10 @@
     "orderClass": {
       "$id": "#/definitions/orderClass",
       "description": "Indicator of the order class.",
-      "examples": [
-        "market",
-        "limit",
-        "liquidity"
-      ],
+      "examples": ["market", "limit", "liquidity"],
       "title": "Order class",
       "type": "string",
-      "enum": [
-        "market",
-        "limit",
-        "liquidity"
-      ]
+      "enum": ["market", "limit", "liquidity"]
     }
   }
 }

--- a/src/schemas/orderClass/v0.2.0.json
+++ b/src/schemas/orderClass/v0.2.0.json
@@ -1,10 +1,7 @@
 {
   "$id": "#orderClass/v0.1.0.json",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "required": [
-    "version",
-    "orderClass"
-  ],
+  "required": ["version", "orderClass"],
   "title": "Order class",
   "type": "object",
   "properties": {
@@ -16,20 +13,10 @@
     "orderClass": {
       "$id": "#/definitions/orderClass",
       "description": "Indicator of the order class.",
-      "examples": [
-        "market",
-        "limit",
-        "liquidity",
-        "twap"
-      ],
+      "examples": ["market", "limit", "liquidity", "twap"],
       "title": "Order class",
       "type": "string",
-      "enum": [
-        "market",
-        "limit",
-        "liquidity",
-        "twap"
-      ]
+      "enum": ["market", "limit", "liquidity", "twap"]
     }
   }
 }

--- a/src/schemas/quote/v0.1.0.json
+++ b/src/schemas/quote/v0.1.0.json
@@ -1,20 +1,14 @@
 {
   "$id": "#quote/v0.1.0.json",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "required": [
-    "sellAmount",
-    "buyAmount",
-    "version"
-  ],
+  "required": ["sellAmount", "buyAmount", "version"],
   "title": "Quote",
   "type": "object",
   "properties": {
     "id": {
       "$id": "#/properties/id",
       "title": "Quote id",
-      "examples": [
-        "XA23443543534FF"
-      ],
+      "examples": ["XA23443543534FF"],
       "type": "string"
     },
     "sellAmount": {

--- a/src/schemas/quote/v0.2.0.json
+++ b/src/schemas/quote/v0.2.0.json
@@ -1,10 +1,7 @@
 {
   "$id": "#quote/v0.2.0.json",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "required": [
-    "version",
-    "slippageBips"
-  ],
+  "required": ["version", "slippageBips"],
   "title": "Quote",
   "type": "object",
   "properties": {
@@ -17,12 +14,7 @@
       "$id": "#/properties/slippageBips",
       "title": "Slippage Bips",
       "description": "Slippage tolerance that was applied to the order to get the limit price. Expressed in Basis Points (BIPS)",
-      "examples": [
-        "5",
-        "10",
-        "20",
-        "100"
-      ],
+      "examples": ["5", "10", "20", "100"],
       "pattern": "^\\d+(\\.\\d+)?$",
       "type": "string"
     }

--- a/src/schemas/referrer/v0.1.0.json
+++ b/src/schemas/referrer/v0.1.0.json
@@ -1,10 +1,7 @@
 {
   "$id": "#referrer/v0.1.0.json",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "required": [
-    "version",
-    "address"
-  ],
+  "required": ["version", "address"],
   "title": "Referrer",
   "type": "object",
   "properties": {

--- a/src/schemas/v0.1.0.json
+++ b/src/schemas/v0.1.0.json
@@ -2,10 +2,7 @@
   "$id": "https://cowswap.exchange/schemas/app-data/v0.1.0.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "description": "Metadata JSON document for adding information to orders.",
-  "required": [
-    "version",
-    "metadata"
-  ],
+  "required": ["version", "metadata"],
   "title": "AppData Root Schema",
   "type": "object",
   "properties": {
@@ -17,9 +14,7 @@
     "appCode": {
       "$id": "#/properties/appCode",
       "description": "The code identifying the CLI, UI, service generating the order.",
-      "examples": [
-        "CoW Swap"
-      ],
+      "examples": ["CoW Swap"],
       "title": "App Code",
       "type": "string"
     },

--- a/src/schemas/v0.2.0.json
+++ b/src/schemas/v0.2.0.json
@@ -2,10 +2,7 @@
   "$id": "https://cowswap.exchange/schemas/app-data/v0.2.0.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "description": "Metadata JSON document for adding information to orders.",
-  "required": [
-    "version",
-    "metadata"
-  ],
+  "required": ["version", "metadata"],
   "title": "AppData Root Schema",
   "type": "object",
   "properties": {
@@ -17,9 +14,7 @@
     "appCode": {
       "$id": "#/properties/appCode",
       "description": "The code identifying the CLI, UI, service generating the order.",
-      "examples": [
-        "CoW Swap"
-      ],
+      "examples": ["CoW Swap"],
       "title": "App Code",
       "type": "string"
     },

--- a/src/schemas/v0.3.0.json
+++ b/src/schemas/v0.3.0.json
@@ -2,10 +2,7 @@
   "$id": "https://cowswap.exchange/schemas/app-data/v0.3.0.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "description": "Metadata JSON document for adding information to orders.",
-  "required": [
-    "version",
-    "metadata"
-  ],
+  "required": ["version", "metadata"],
   "title": "AppData Root Schema",
   "type": "object",
   "properties": {
@@ -17,9 +14,7 @@
     "appCode": {
       "$id": "#/properties/appCode",
       "description": "The code identifying the CLI, UI, service generating the order.",
-      "examples": [
-        "CoW Swap"
-      ],
+      "examples": ["CoW Swap"],
       "title": "App Code",
       "type": "string"
     },
@@ -28,12 +23,7 @@
       "description": "Environment from which the order came from",
       "title": "Environment",
       "type": "string",
-      "examples": [
-        "production",
-        "development",
-        "staging",
-        "ens"
-      ]
+      "examples": ["production", "development", "staging", "ens"]
     },
     "metadata": {
       "$id": "#/properties/metadata",

--- a/src/schemas/v0.4.0.json
+++ b/src/schemas/v0.4.0.json
@@ -2,10 +2,7 @@
   "$id": "https://cowswap.exchange/schemas/app-data/v0.4.0.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "description": "Metadata JSON document for adding information to orders.",
-  "required": [
-    "version",
-    "metadata"
-  ],
+  "required": ["version", "metadata"],
   "title": "AppData Root Schema",
   "type": "object",
   "properties": {
@@ -17,9 +14,7 @@
     "appCode": {
       "$id": "#/properties/appCode",
       "description": "The code identifying the CLI, UI, service generating the order.",
-      "examples": [
-        "CoW Swap"
-      ],
+      "examples": ["CoW Swap"],
       "title": "App Code",
       "type": "string"
     },
@@ -28,12 +23,7 @@
       "description": "Environment from which the order came from.",
       "title": "Environment",
       "type": "string",
-      "examples": [
-        "production",
-        "development",
-        "staging",
-        "ens"
-      ]
+      "examples": ["production", "development", "staging", "ens"]
     },
     "metadata": {
       "$id": "#/properties/metadata",

--- a/src/schemas/v0.5.0.json
+++ b/src/schemas/v0.5.0.json
@@ -2,10 +2,7 @@
   "$id": "https://cowswap.exchange/schemas/app-data/v0.5.0.json",
   "$schema": "http://json-schema.org/draft-07/schema",
   "description": "Metadata JSON document for adding information to orders.",
-  "required": [
-    "version",
-    "metadata"
-  ],
+  "required": ["version", "metadata"],
   "title": "AppData Root Schema",
   "type": "object",
   "properties": {
@@ -17,9 +14,7 @@
     "appCode": {
       "$id": "#/properties/appCode",
       "description": "The code identifying the CLI, UI, service generating the order.",
-      "examples": [
-        "CoW Swap"
-      ],
+      "examples": ["CoW Swap"],
       "title": "App Code",
       "type": "string"
     },
@@ -28,12 +23,7 @@
       "description": "Environment from which the order came from.",
       "title": "Environment",
       "type": "string",
-      "examples": [
-        "production",
-        "development",
-        "staging",
-        "ens"
-      ]
+      "examples": ["production", "development", "staging", "ens"]
     },
     "metadata": {
       "$id": "#/properties/metadata",


### PR DESCRIPTION
Just ran `yarn prettier -w src/schemas` to make sure the JSON files have consistent formatting. Noticed this when implementing #29.