### PR TITLE
Fix concurrency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/app-data",
-  "version": "1.0.2-rc.0",
+  "version": "1.0.2-rc.1",
   "description": "CowProtocol AppData schema definitions",
   "type": "module",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/app-data",
-  "version": "1.0.1",
+  "version": "1.0.2-rc.0",
   "description": "CowProtocol AppData schema definitions",
   "type": "module",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/app-data",
-  "version": "1.0.2-rc.1",
+  "version": "1.0.2",
   "description": "CowProtocol AppData schema definitions",
   "type": "module",
   "source": "src/index.ts",


### PR DESCRIPTION
We had a concurrency issue loading the validation

The issue was that this line is asynchronous https://github.com/cowprotocol/app-data/pull/33/files#diff-d51cb43878dd14f5e5977647c2a57383a17958b189e74b098cbbee970cb631efL27

So multiple calls to this function, will add the schema several times!

We had some concurrency control to get the AJV instance https://github.com/cowprotocol/app-data/pull/33/files#diff-d51cb43878dd14f5e5977647c2a57383a17958b189e74b098cbbee970cb631efL20

<img width="986" alt="image" src="https://github.com/cowprotocol/app-data/assets/2352112/7612619a-b087-48a7-b6ee-d87182b72d87">


This PR makes keeps a cache of the validators for different versions. This way, we will only instantiate once the validator