### PR TITLE
fix: ignore ts errors

### DIFF
--- a/src/api/getAppDataSchema.spec.ts
+++ b/src/api/getAppDataSchema.spec.ts
@@ -7,6 +7,7 @@ describe('getAppDataSchema', () => {
     // when
     const schema = await getAppDataSchema(version)
     // then
+    // @ts-ignore
     expect(schema.$id).toMatch(version)
   })
 
@@ -48,6 +49,7 @@ function _buildAssertVersionFn(version: string) {
     // when
     const schema = await getAppDataSchema(version)
     // then
+    // @ts-ignore
     expect(schema.$id).toMatch(version)
   }
 }


### PR DESCRIPTION
This PR:

1. Adds explicit ts ignore to fix tsc issues in downstream consumers when generating typedoc.