### PR TITLE
fix: fix ethers utils dynamic imports

### DIFF
--- a/src/api/appDataHexToCid.ts
+++ b/src/api/appDataHexToCid.ts
@@ -68,7 +68,8 @@ async function _toCidBytes({
   hashingLength,
   multihashHex,
 }: ToCidParmams): Promise<Uint8Array> {
-  const { arrayify } = await import('ethers/lib/utils')
+  const module = await import('ethers/lib/utils')
+  const { arrayify } = module.default || module
   const hashBytes = arrayify(multihashHex)
 
   // Concat prefix and multihash

--- a/src/api/appDataToCid.ts
+++ b/src/api/appDataToCid.ts
@@ -98,7 +98,8 @@ export async function _appDataToCidAux(
  * @returns the IPFS CID v0 of the content
  */
 async function _appDataToCid(fullAppDataJson: string): Promise<string> {
-  const { keccak256, toUtf8Bytes } = await import('ethers/lib/utils')
+  const module = await import('ethers/lib/utils')
+  const { keccak256, toUtf8Bytes } = module.default || module
 
   const appDataHex = await keccak256(toUtf8Bytes(fullAppDataJson))
   return appDataHexToCid(appDataHex)


### PR DESCRIPTION
Vite for some reason wrongly resolves dynamic imports.
To fix that we should check both: default exports and just exports