### PR TITLE
Return appData

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ const appDataDoc = await metadataApi.generateAppDataDoc({
   },
 })
 
-const { cid, appDataHex } = await metadataApi.appDataToCid(appDataDoc)
+const { cid, appDataHex, appDataContent } = await metadataApi.appDataToCid(appDataDoc)
 
 // 💡🐮 You should use appDataHex as the appData value in the CoW Order. "cid" Identifies the metadata associated to the CoW order in IPFS
 

--- a/src/api/appDataToCid.spec.ts
+++ b/src/api/appDataToCid.spec.ts
@@ -11,6 +11,7 @@ import {
   CID_LEGACY,
 } from '../mocks'
 import { appDataToCid, appDataToCidLegacy } from './appDataToCid'
+import { stringifyDeterministic } from '..'
 
 beforeEach(() => {
   fetchMock.resetMocks()
@@ -27,7 +28,7 @@ describe('appDataToCid', () => {
 
     // then
     expect(result).not.toBeFalsy()
-    expect(result).toEqual({ cid: CID, appDataHex: APP_DATA_HEX })
+    expect(result).toEqual({ cid: CID, appDataHex: APP_DATA_HEX, appDataContent: APP_DATA_STRING })
   })
 
   test('Happy path with appData doc ', async () => {
@@ -36,7 +37,11 @@ describe('appDataToCid', () => {
 
     // then
     expect(result).not.toBeFalsy()
-    expect(result).toEqual({ cid: CID, appDataHex: APP_DATA_HEX })
+    expect(result).toEqual({
+      cid: CID,
+      appDataHex: APP_DATA_HEX,
+      appDataContent: await stringifyDeterministic(APP_DATA_DOC),
+    })
   })
 
   test('Happy path with appData doc 2 ', async () => {
@@ -45,7 +50,7 @@ describe('appDataToCid', () => {
 
     // then
     expect(result).not.toBeFalsy()
-    expect(result).toEqual({ cid: CID_2, appDataHex: APP_DATA_HEX_2 })
+    expect(result).toEqual({ cid: CID_2, appDataHex: APP_DATA_HEX_2, appDataContent: APP_DATA_STRING_2 })
   })
 
   test('Throws with invalid appDoc', async () => {
@@ -69,7 +74,11 @@ describe('appDataToCidLegacy', () => {
     const result = await appDataToCidLegacy(APP_DATA_DOC)
     // then
     expect(result).not.toBeFalsy()
-    expect(result).toEqual({ cid: CID_LEGACY, appDataHex: APP_DATA_HEX_LEGACY })
+    expect(result).toEqual({
+      cid: CID_LEGACY,
+      appDataHex: APP_DATA_HEX_LEGACY,
+      appDataContent: JSON.stringify(APP_DATA_DOC), // For the legacy-mode we use plain JSON.stringify to mantain backwards compatibility, however this is not a good idea to do since JSON.stringify. Better specify the doc as a fullAppData string or use stringifyDeterministic
+    })
   })
 
   test('Throws with invalid appDoc', async () => {

--- a/src/api/appDataToCid.ts
+++ b/src/api/appDataToCid.ts
@@ -83,7 +83,7 @@ export async function _appDataToCidAux(
       throw new MetaDataError(`Could not extract appDataHex from calculated cid ${cid}`)
     }
 
-    return { cid, appDataHex }
+    return { cid, appDataHex, appDataContent: fullAppData }
   } catch (e) {
     const error = e as MetaDataError
     console.error('Failed to calculate appDataHex', error)

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type IpfsHashInfo = {
   cid: string
 
   /**
-   * full appData content
+   * Full appData content. It will be a the exact string that if hashed using keccak-256 you would get the returned appDataHex
    */
   appDataContent: string
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,11 @@ export type IpfsHashInfo = {
   cid: string
 
   /**
+   * full appData content
+   */
+  appDataContent: string
+
+  /**
    * appData hex for CoW Orders. Its value is the multihash part of the IPFS CID, therefore it points to a IPFS document.
    * Because its just the multihash, it doesn't have any infomation regarding the encoding and hashing algorithm. These parts are implicit.
    *


### PR DESCRIPTION
This PR makes sure we return the relevant UTF-8 string that it was hashed to get the `appDataHex`

This is convenient if you pass a document, because you don't know exactly the hashing method that was used. 
