### PR TITLE
Make types stricter

### DIFF
--- a/src/generatedTypes/v0.11.0.ts
+++ b/src/generatedTypes/v0.11.0.ts
@@ -136,5 +136,4 @@ export interface CoWHook {
 export interface Widget {
   appCode: AppCode1;
   environment?: Environment1;
-  [k: string]: unknown;
 }

--- a/src/generatedTypes/v1.0.0.ts
+++ b/src/generatedTypes/v1.0.0.ts
@@ -145,10 +145,8 @@ export interface CoWHook {
 export interface Widget {
   appCode: AppCode1;
   environment?: Environment1;
-  [k: string]: unknown;
 }
 export interface PartnerFee {
   bps: BasisPointBPS;
   recipient: PartnerAccount;
-  [k: string]: unknown;
 }

--- a/src/schemas/partnerFee/v0.1.0.json
+++ b/src/schemas/partnerFee/v0.1.0.json
@@ -4,6 +4,7 @@
   "required": ["bps", "recipient"],
   "title": "Partner fee",
   "type": "object",
+  "additionalItems": false,
   "properties": {
     "bps": {
       "title": "Basis Point (BPS)",

--- a/src/schemas/partnerFee/v0.1.0.json
+++ b/src/schemas/partnerFee/v0.1.0.json
@@ -4,7 +4,7 @@
   "required": ["bps", "recipient"],
   "title": "Partner fee",
   "type": "object",
-  "additionalItems": false,
+  "additionalProperties": false,
   "properties": {
     "bps": {
       "title": "Basis Point (BPS)",

--- a/src/schemas/widget/v0.1.0.json
+++ b/src/schemas/widget/v0.1.0.json
@@ -4,7 +4,7 @@
   "required": ["appCode"],
   "title": "Widget",
   "type": "object",
-  "additionalItems": false,
+  "additionalProperties": false,
   "properties": {
     "appCode": {
       "$id": "#/properties/appCodeWidget",

--- a/src/schemas/widget/v0.1.0.json
+++ b/src/schemas/widget/v0.1.0.json
@@ -4,6 +4,7 @@
   "required": ["appCode"],
   "title": "Widget",
   "type": "object",
+  "additionalItems": false,
   "properties": {
     "appCode": {
       "$id": "#/properties/appCodeWidget",


### PR DESCRIPTION
This PR don't generate a new version, because it doesn't change the format of the app-data, just prevents the types of the objects to include additional properties.


This makes the generated typescript be:

<img width="425" alt="image" src="https://github.com/cowprotocol/app-data/assets/2352112/c606abe5-377f-4b07-9bf5-c46b47fdc884">


Instead of:

<img width="293" alt="image" src="https://github.com/cowprotocol/app-data/assets/2352112/1142bdea-b9ec-4e6b-8cc3-24482b6e99ca">
