### PR TITLE
ci: fix compile script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "clean": "rm -rf dist/* && rm -rf src/generatedTypes/* && rm -rf schemas/",
-    "compile": "npx ts-node --esm src/scripts/compile.ts --experimental-specifier-resolution=node",
+    "compile": "node --loader ts-node/esm src/scripts/compile.ts --experimental-specifier-resolution=node",
     "build": "yarn clean && yarn compile && microbundle -f modern,esm,cjs",
     "test": "jest",
     "prepare": "yarn build && yarn test"


### PR DESCRIPTION
Docs build was failing: https://vercel.com/cowswap/docs/7SsUsbEjTZT9vjYBPyvmMtdTz44m
Error context: https://github.com/TypeStrong/ts-node/issues/1997