### PR TITLE
chore: deprecate ipfs fns

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const appCode = 'YOUR_APP_CODE'
 const environment = 'prod'
 const referrer = { address: `REFERRER_ADDRESS` }
 
-const quote = { slippageBips: '0.5' } // Slippage percent, it's 0 to 100
+const quote = { slippageBips: 1 } // Slippage percent, it's 0 to 100
 const orderClass = { orderClass: 'market' } // "market" | "limit" | "liquidity"
 
 const appDataDoc = await metadataApi.generateAppDataDoc({

--- a/README.md
+++ b/README.md
@@ -35,27 +35,6 @@ const appDataDoc = await metadataApi.generateAppDataDoc({
     orderClass,
   },
 })
-
-const { cid, appDataHex, appDataContent } = await metadataApi.appDataToCid(appDataDoc)
-
-// 💡🐮 You should use appDataHex as the appData value in the CoW Order. "cid" Identifies the metadata associated to the CoW order in IPFS
-
-// You can derive the CID from the appDataHex of any order
-const actualCid = await metadataApi.appDataHexToCid(appDataHex)
-console.log(cid === actualCid) // Should be true
-
-// You can derive the appDataHex from the CID of any order
-const actualAppDatahex = await metadataApi.appDataHexToCid(cid)
-console.log(appDataHex === actualAppDatahex) // Should be true
-
-// You can retrieve the JSON document from the CID
-// 🔔 NOTE: for this to work, someone needs to upload the document to IPFS (the CoW API does it, but anyone could upload it too)
-const actualAppDoc = await fetchDocFromCid(cid)
-expect(actualAppDoc).toBeEqual(appDataDoc)
-
-// You can also retrieve the JSON from the appDataHex
-const actualAppDoc2 = await fetchDocFromAppDataHex(appDataHex)
-expect(actualAppDoc2).toBeEqual(appDataDoc)
 ```
 
 ### Schemas
@@ -145,7 +124,7 @@ Fork the repo so you can create a new PR. Then:
 
 - We create one directory per schema, so we can keep track of all versions. Create the directory and initial schema definition: `<meta-data-name>/v0.1.0.json`
 - Add it to the main schema you just created in step 1: `"$ref": "<meta-data-name>/v0.1.0.json#"`.
-- Example: https://github.com/cowprotocol/app-data/pull/44/files#diff-7f7a61b478245dfda004f64bd68ac55ef68cbeb5d6d90d77e1cdbd2b7e1212b8R56
+- Example: <https://github.com/cowprotocol/app-data/pull/44/files#diff-7f7a61b478245dfda004f64bd68ac55ef68cbeb5d6d90d77e1cdbd2b7e1212b8R56>
 
 3. If you are modifying an existing meta-data
 
@@ -156,7 +135,7 @@ Fork the repo so you can create a new PR. Then:
 4. Modify the `compile.ts` script
 
 - Add the exported constant with the latest version in, and the new metadata:
-  - For example: https://github.com/cowprotocol/app-data/pull/44/commits/aeef8a58e7bbd2a53664ce396011cb157a18406d
+  - For example: <https://github.com/cowprotocol/app-data/pull/44/commits/aeef8a58e7bbd2a53664ce396011cb157a18406d>
 
 4. Generate the typescript types
 
@@ -164,7 +143,7 @@ Fork the repo so you can create a new PR. Then:
 
 5. Make a test focusing on the new or modified meta-data:
 
-- https://github.com/cowprotocol/app-data/pull/44/files#diff-e755a2ecce42f09829d5c7dc1de8853d1d00ef56eaadc2709601c87b9be8ddfbR556
-- Don't forget to use the right version of the schema in your test: https://github.com/cowprotocol/app-data/pull/44/files#diff-e755a2ecce42f09829d5c7dc1de8853d1d00ef56eaadc2709601c87b9be8ddfbR11
+- <https://github.com/cowprotocol/app-data/pull/44/files#diff-e755a2ecce42f09829d5c7dc1de8853d1d00ef56eaadc2709601c87b9be8ddfbR556>
+- Don't forget to use the right version of the schema in your test: <https://github.com/cowprotocol/app-data/pull/44/files#diff-e755a2ecce42f09829d5c7dc1de8853d1d00ef56eaadc2709601c87b9be8ddfbR11>
 
 6. Create the PR and document it together with the motivation for the changes

--- a/src/api/appDataHexToCid.ts
+++ b/src/api/appDataHexToCid.ts
@@ -1,5 +1,11 @@
 import { MetaDataError } from '../consts'
 
+/**
+ * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
+ *
+ * @param appDataHex
+ * @returns
+ */
 export async function appDataHexToCid(appDataHex: string): Promise<string> {
   const cid = await _appDataHexToCid(appDataHex)
   _assertCid(cid, appDataHex)
@@ -7,6 +13,12 @@ export async function appDataHexToCid(appDataHex: string): Promise<string> {
   return cid
 }
 
+/**
+ * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
+ *
+ * @param appDataHex
+ * @returns
+ */
 export async function appDataHexToCidLegacy(appDataHex: string): Promise<string> {
   const cid = await _appDataHexToCidLegacy(appDataHex)
   _assertCid(cid, appDataHex)

--- a/src/api/appDataToCid.ts
+++ b/src/api/appDataToCid.ts
@@ -9,6 +9,8 @@ import { validateAppDataDoc } from './validateAppDataDoc'
 /**
  * Calculates appDataHex without publishing file to IPFS
  *
+ * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
+ *
  * This method is intended to quickly generate the appDataHex independent
  * of IPFS upload/pinning
  *
@@ -19,6 +21,8 @@ export async function appDataToCid(appData: AnyAppDataDocVersion): Promise<IpfsH
 /**
  * Calculates appDataHex without publishing file to IPFS
  *
+ * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
+ *
  * This method is intended to quickly generate the appDataHex independent
  * of IPFS upload/pinning
  *
@@ -26,6 +30,12 @@ export async function appDataToCid(appData: AnyAppDataDocVersion): Promise<IpfsH
  */
 export async function appDataToCid(fullAppData: string): Promise<IpfsHashInfo | void>
 
+/**
+ * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
+ *
+ * @param appDataAux
+ * @returns
+ */
 export async function appDataToCid(appDataAux: AnyAppDataDocVersion | string): Promise<IpfsHashInfo> {
   return _appDataToCidAux(appDataAux, _appDataToCid)
 }
@@ -54,6 +64,12 @@ export async function appDataToCidLegacy(appData: AnyAppDataDocVersion): Promise
  */
 export async function appDataToCidLegacy(fullAppData: string): Promise<IpfsHashInfo | void>
 
+/**
+ * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
+ *
+ * @param appDataAux
+ * @returns
+ */
 export async function appDataToCidLegacy(appDataAux: AnyAppDataDocVersion | string): Promise<IpfsHashInfo | void> {
   // For the legacy-mode we use plain JSON.stringify to mantain backwards compatibility, however this is not a good idea to do since JSON.stringify. Better specify the doc as a fullAppData string or use stringifyDeterministic
   const fullAppData = JSON.stringify(appDataAux)

--- a/src/api/cidToAppDataHex.ts
+++ b/src/api/cidToAppDataHex.ts
@@ -1,5 +1,11 @@
 import { extractDigest } from '../utils/ipfs'
 
+/**
+ * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
+ *
+ * @param cid
+ * @returns
+ */
 export async function cidToAppDataHex(cid: string): Promise<string> {
   return extractDigest(cid)
 }

--- a/src/api/fetchDocFromAppData.ts
+++ b/src/api/fetchDocFromAppData.ts
@@ -5,6 +5,8 @@ import { fetchDocFromCid } from './fetchDocFromCid'
 
 /**
  *
+ * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
+ *
  * @param appDataHex Derives the CID from the appData hex, and fetches and parses the document from IPFS
  * @param ipfsUri URL of the IPFS gateway to use for the fetch
  *
@@ -20,7 +22,7 @@ export async function fetchDocFromAppDataHex(
 /**
  * Fetches the document from IPFS using the appData hex
  *
- * @deprecated
+ * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
  *
  * @param appDataHex
  * @param ipfsUri

--- a/src/api/fetchDocFromCid.ts
+++ b/src/api/fetchDocFromCid.ts
@@ -1,6 +1,13 @@
 import { AnyAppDataDocVersion } from 'generatedTypes'
 import { DEFAULT_IPFS_READ_URI } from '../consts'
 
+/**
+ * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
+ *
+ * @param cid
+ * @param ipfsUri
+ * @returns
+ */
 export async function fetchDocFromCid(cid: string, ipfsUri = DEFAULT_IPFS_READ_URI): Promise<AnyAppDataDocVersion> {
   const { default: fetch } = await import('cross-fetch')
   const response = await fetch(`${ipfsUri}/${cid}`)

--- a/src/api/generateAppDataDoc.ts
+++ b/src/api/generateAppDataDoc.ts
@@ -20,15 +20,13 @@ const DEFAULT_APP_DATA_DOC = {
  *   "environment": "local",
  *   "metadata": {
  *     "quote": {
- *       "slippageBips": "50",
- *       "version": "0.2.0"
+ *       "slippageBips": 50
  *     },
  *     "orderClass": {
- *       "orderClass": "market",
- *       "version": "0.1.0"
+ *       "orderClass": "market"
  *     }
  *   },
- *   "version": "0.5.0"
+ *   "version": "1.2.0"
  * }
  */
 export async function generateAppDataDoc(params?: AppDataParams): Promise<LatestAppDataDocVersion> {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -15,16 +15,17 @@ export class MetadataApi {
   generateAppDataDoc = generateAppDataDoc
   validateAppDataDoc = validateAppDataDoc
 
-  // appData / CID conversion
+  // ---- Deprecated methods ----
+
+  // appData / CID conversion (deprecated)
   appDataToCid = appDataToCid // (appData | fullAppData) --> cid
   appDataHexToCid = appDataHexToCid // appDataHex --> cid
   cidToAppDataHex = cidToAppDataHex // cid --> appDataHex
 
-  // Fetch appData document from IPFS
+  // Fetch appData document from IPFS (deprecated)
   fetchDocFromCid = fetchDocFromCid // cid --> document
   fetchDocFromAppDataHex = fetchDocFromAppDataHex // appDataHex --> appData
 
-  // ---- Deprecated methods ----
   // Upload to IPFS (deprecated)
   uploadMetadataDocToIpfsLegacy = uploadMetadataDocToIpfsLegacy //  appData --> cid + publish IPFS
   appDataToCidLegacy = appDataToCidLegacy // (appData | fullAppData) --> cid


### PR DESCRIPTION
# Summary

No functional changes, just marking IPFS related fns as deprecated and removing mention to it from README.