### PR TITLE
feat: add dappId to hooks schema

### DIFF
--- a/src/generatedTypes/index.ts
+++ b/src/generatedTypes/index.ts
@@ -14,22 +14,24 @@ import * as v0_9_0 from './v0.9.0'
 import * as v1_0_0 from './v1.0.0'
 import * as v1_1_0 from './v1.1.0'
 import * as v1_2_0 from './v1.2.0'
+import * as v1_3_0 from './v1.3.0'
 
-export * as latest from './v1.2.0'
+export * as latest from './v1.3.0'
 
-export const LATEST_APP_DATA_VERSION = '1.2.0'
+export const LATEST_APP_DATA_VERSION = '1.3.0'
 export const LATEST_QUOTE_METADATA_VERSION = '1.1.0'
 export const LATEST_REFERRER_METADATA_VERSION = '0.2.0'
 export const LATEST_ORDER_CLASS_METADATA_VERSION = '0.3.0'
 export const LATEST_UTM_METADATA_VERSION = '0.2.0'
-export const LATEST_HOOKS_METADATA_VERSION = '0.1.0'
+export const LATEST_HOOKS_METADATA_VERSION = '0.2.0'
 export const LATEST_SIGNER_METADATA_VERSION = '0.1.0'
 export const LATEST_WIDGET_METADATA_VERSION = '0.1.0'
 export const LATEST_PARTNER_FEE_METADATA_VERSION = '0.1.0'
 export const LATEST_REPLACED_ORDER_METADATA_VERSION = '0.1.0'
 
-export type LatestAppDataDocVersion = v1_2_0.AppDataRootSchema
+export type LatestAppDataDocVersion = v1_3_0.AppDataRootSchema
 export type AnyAppDataDocVersion = 
+  | v1_3_0.AppDataRootSchema
   | v1_2_0.AppDataRootSchema
   | v1_1_0.AppDataRootSchema
   | v1_0_0.AppDataRootSchema
@@ -46,6 +48,7 @@ export type AnyAppDataDocVersion =
   | v0_1_0.AppDataRootSchema
 
 export {
+  v1_3_0,
   v1_2_0,
   v1_1_0,
   v1_0_0,

--- a/src/schemas/definitions.json
+++ b/src/schemas/definitions.json
@@ -40,6 +40,13 @@
       "title": "Order UID",
       "examples": ["0xff2e2e54d178997f173266817c1e9ed6fee1a1aae4b43971c53b543cffcc2969845c6f5599fbb25dbdd1b9b013daf85c03f3c63763e4bc4a"],
       "type": "string"
+    },
+    "dappId": {
+      "$id": "#/definitions/dappId",
+      "pattern": "^[a-fA-F0-9]{64}$",
+      "title": "A hex string representing a dApp ID",
+      "examples": ["75716a3cb48fdbb43ebdff58ce6c541f6a2c269be690513131355800367f2da2"],
+      "type": "string"
     }
   }
 }

--- a/src/schemas/hook/v0.2.0.json
+++ b/src/schemas/hook/v0.2.0.json
@@ -1,0 +1,40 @@
+{
+  "$id": "#hook/v0.2.0.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "required": [
+    "target",
+    "callData",
+    "gasLimit"
+  ],
+  "title": "CoW Hook",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "target": {
+      "$ref": "../definitions.json#/definitions/ethereumAddress",
+      "title": "Hook Target",
+      "description": "The contract to call for the hook"
+    },
+    "callData": {
+      "$id": "#/properties/callData",
+      "title": "Hook CallData",
+      "description": "The calldata to use when calling the hook",
+      "type": "string",
+      "pattern": "^0x[a-fA-F0-9]*$",
+      "examples": [
+        "0x",
+        "0x01020304"
+      ]
+    },
+    "gasLimit": {
+      "$ref": "../definitions.json#/definitions/bigNumber",
+      "title": "Hook Gas Limit",
+      "description": "The gas limit (in gas units) for the hook"
+    },
+    "dappId": {
+      "$ref": "../definitions.json#/definitions/dappId",
+      "title": "Id of the dApp which has built the hook",
+      "description": "CoW Swap has an interface that allows dApps to build hooks for orders. This field is used to identify the dApp that has built the hook."
+    }
+  }
+}

--- a/src/schemas/hooks/v0.2.0.json
+++ b/src/schemas/hooks/v0.2.0.json
@@ -1,0 +1,35 @@
+{
+  "$id": "#hooks/v0.2.0.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "default": {},
+  "required": [],
+  "title": "Order interaction hooks",
+  "description": "Optional Pre and Post order interaction hooks attached to a single order",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "$ref": "../definitions.json#/definitions/version",
+      "readOnly": true,
+      "default": "0.1.0"
+    },
+    "pre": {
+      "$id": "#/properties/hooks/pre",
+      "title": "Pre-Hooks",
+      "description": "CoW Hooks to call before an order executes",
+      "type": "array",
+      "items": {
+        "$ref": "../hook/v0.2.0.json#"
+      }
+    },
+    "post": {
+      "$id": "#/properties/hooks/post",
+      "title": "Post-Hooks",
+      "description": "CoW Hooks to call after an order executes",
+      "type": "array",
+      "items": {
+        "$ref": "../hook/v0.2.0.json#"
+      }
+    }
+  }
+}

--- a/src/schemas/v1.3.0.json
+++ b/src/schemas/v1.3.0.json
@@ -1,0 +1,78 @@
+{
+  "$id": "https://cowswap.exchange/schemas/app-data/v1.3.0.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "description": "Metadata JSON document for adding information to orders.",
+  "required": [
+    "version",
+    "metadata"
+  ],
+  "title": "AppData Root Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "$ref": "definitions.json#/definitions/version",
+      "readOnly": true,
+      "default": "1.3.0"
+    },
+    "appCode": {
+      "$id": "#/properties/appCode",
+      "description": "The code identifying the CLI, UI, service generating the order.",
+      "examples": [
+        "CoW Swap"
+      ],
+      "title": "App Code",
+      "type": "string"
+    },
+    "environment": {
+      "$id": "#/properties/environment",
+      "description": "Environment from which the order came from.",
+      "title": "Environment",
+      "type": "string",
+      "examples": [
+        "production",
+        "development",
+        "staging",
+        "ens"
+      ]
+    },
+    "metadata": {
+      "$id": "#/properties/metadata",
+      "default": {},
+      "description": "Each metadata will specify one aspect of the order.",
+      "required": [],
+      "title": "Metadata",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "signer": {
+          "$ref": "signer/v0.1.0.json#"
+        },
+        "referrer": {
+          "$ref": "referrer/v0.2.0.json#"
+        },
+        "utm": {
+          "$ref": "utm/v0.2.0.json#"
+        },
+        "quote": {
+          "$ref": "quote/v1.1.0.json#"
+        },
+        "orderClass": {
+          "$ref": "orderClass/v0.3.0.json#"
+        },
+        "hooks": {
+          "$ref": "hooks/v0.2.0.json#"
+        },
+        "widget": {
+          "$ref": "widget/v0.1.0.json#"
+        },
+        "partnerFee": {
+          "$ref": "partnerFee/v0.1.0.json#"
+        },
+        "replacedOrder": {
+          "$ref": "replacedOrder/v0.1.0.json#"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
We need an identificator to match hooks from order with dapp that was used to create the hooks.
There is a new `dappid` field in hook schema, which is an optional hex string with 64 length.