### PR TITLE
feat: expose a file with just the latest

### DIFF
--- a/src/generatedTypes/index.ts
+++ b/src/generatedTypes/index.ts
@@ -16,7 +16,7 @@ import * as v1_1_0 from './v1.1.0'
 import * as v1_2_0 from './v1.2.0'
 import * as v1_3_0 from './v1.3.0'
 
-export * as latest from './v1.3.0'
+export * from './latest'
 
 export const LATEST_APP_DATA_VERSION = '1.3.0'
 export const LATEST_QUOTE_METADATA_VERSION = '1.1.0'

--- a/src/generatedTypes/latest.ts
+++ b/src/generatedTypes/latest.ts
@@ -1,0 +1,3 @@
+// generated file, do not edit manually
+
+export * as latest from './v1.3.0'

--- a/src/scripts/compile.ts
+++ b/src/scripts/compile.ts
@@ -75,9 +75,9 @@ async function compile(): Promise<void> {
     const latestPartnerFeeVersion = await getLatestMetadataDocVersion('partnerFee')
     const latestReplacedOrderVersion = await getLatestMetadataDocVersion('replacedOrder')
 
-    const exportLatest = `export * as latest from './${latest}'\n`
     const additionalTypesExport = `
-${exportLatest}
+export * from './latest'
+
 export const LATEST_APP_DATA_VERSION = '${extractSemver(latest)}'
 export const LATEST_QUOTE_METADATA_VERSION = '${extractSemver(latestQuoteVersion)}'
 export const LATEST_REFERRER_METADATA_VERSION = '${extractSemver(latestReferrerVersion)}'
@@ -99,7 +99,7 @@ export {${versions.map((version) => `\n  ${versionNameToExport(version)}`)}
     await typesIndexFile.write(additionalTypesExport)
 
     // Writes exports to types/latest.ts
-    await latestIndexFile.write(exportLatest)
+    await latestIndexFile.write(`export * as latest from './${latest}'\n`)
   }
 
   // Closes all files
@@ -119,7 +119,16 @@ function extractSemver(name: string): string {
 }
 
 async function getLatestMetadataDocVersion(
-  metadataDocName: 'quote' | 'referrer' | 'orderClass' | 'utm' | 'hooks' | 'signer' | 'widget' | 'partnerFee' | 'replacedOrder'
+  metadataDocName:
+    | 'quote'
+    | 'referrer'
+    | 'orderClass'
+    | 'utm'
+    | 'hooks'
+    | 'signer'
+    | 'widget'
+    | 'partnerFee'
+    | 'replacedOrder'
 ): Promise<string> {
   const metadataPath = path.join(SCHEMAS_SRC_PATH, metadataDocName)
   const versions = await fs.promises.readdir(metadataPath)


### PR DESCRIPTION
This PR include an additional export file (`latest.ts`) with the latest types for app-data

## Context

Solve the duplication in the docs for older versions of the app-data
![image](https://github.com/user-attachments/assets/0aef3023-2b57-4eb7-986a-bb6cd33cc97a)

![image](https://github.com/user-attachments/assets/9e4583c7-72ba-4603-80e0-ad972788e762)
