### PR TITLE
Remove cross-fetch in favour of native fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,13 +52,11 @@
   },
   "dependencies": {
     "ajv": "^8.11.0",
-    "cross-fetch": "^3.1.5",
     "ipfs-only-hash": "^4.0.0",
     "json-stringify-deterministic": "^1.0.8",
     "multiformats": "^9.6.4"
   },
   "peerDependencies": {
-    "cross-fetch": "^3.x",
     "ethers": "^5.0.0",
     "ipfs-only-hash": "^4.x",
     "multiformats": "^9.x"

--- a/setupTests.js
+++ b/setupTests.js
@@ -3,6 +3,3 @@ import fetchMock from 'jest-fetch-mock'
 global.window = global
 
 fetchMock.enableMocks()
-
-jest.setMock('cross-fetch', fetchMock)
-

--- a/src/api/fetchDocFromCid.ts
+++ b/src/api/fetchDocFromCid.ts
@@ -9,7 +9,6 @@ import { DEFAULT_IPFS_READ_URI } from '../consts'
  * @returns
  */
 export async function fetchDocFromCid(cid: string, ipfsUri = DEFAULT_IPFS_READ_URI): Promise<AnyAppDataDocVersion> {
-  const { default: fetch } = await import('cross-fetch')
   const response = await fetch(`${ipfsUri}/${cid}`)
 
   return await response.json()

--- a/src/api/uploadMetadataDocToIpfsLegacy.ts
+++ b/src/api/uploadMetadataDocToIpfsLegacy.ts
@@ -42,8 +42,6 @@ export async function _pinJsonInPinataIpfs(
   file: unknown,
   { writeUri = DEFAULT_IPFS_WRITE_URI, pinataApiKey = '', pinataApiSecret = '' }: Ipfs
 ): Promise<PinataPinResponse> {
-  const { default: fetch } = await import('cross-fetch')
-
   if (!pinataApiKey || !pinataApiSecret) {
     throw new MetaDataError('You need to pass IPFS api credentials.')
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3118,7 +3118,7 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@^3.0.4, cross-fetch@^3.1.5:
+cross-fetch@^3.0.4:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==


### PR DESCRIPTION
I was running into lots of peer dependency issues and thought that this seemed like an unnecessary dependency. Note that jest-fetch-mock still uses it, but as a dev-dependency.