### PR TITLE
fix: Could not find a declaration file for module '@cowprotocol/app-data'

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "source": "src/index.ts",
   "exports": {
-    "require": "./dist/index.cjs",
-    "default": "./dist/index.modern.mjs"
+    "require": { "import": "./dist/index.cjs", "types": "./dist/index.d.ts" },
+    "default": { "import": "./dist/index.modern.mjs", "types": "./dist/index.d.ts" }
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.module.js",


### PR DESCRIPTION
While working on this PR https://github.com/safe-global/safe-wallet-monorepo/pull/5799 for the new Safe Mobile app the lint job failed out of nowhere. I was updating react-native and expo and there seem to be some changes to the way the metro and typescript are treating packages in react-native so I was greeted by:

```
src/hooks/useTransactionType/index.tsx:2:51 - error TS7016: Could not find a declaration file for module '@cowprotocol/app-data'. '/Users/dd/Development/safe/safe-wallet-monorepo/node_modules/@cowprotocol/app-data/dist/index.modern.mjs' implicitly has an 'any' type.
  There are types at '/Users/dd/Development/safe/safe-wallet-monorepo/node_modules/@cowprotocol/app-data/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@cowprotocol/app-data' library may need to update its package.json or typings.
  ```

It seems that if there is an export field in package.json it also has to specify the type, otherwise the global type field is being ignored. In my tests this lint error is gone. 