### PR TITLE
Test fix export types default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,18 @@
 {
   "name": "@cowprotocol/app-data",
-  "version": "2.5.1",
+  "version": "2.5.2-rc.0",
   "description": "CowProtocol AppData schema definitions",
   "type": "module",
   "source": "src/index.ts",
   "exports": {
-    "require": { "import": "./dist/index.cjs", "types": "./dist/index.d.ts" },
-    "default": { "import": "./dist/index.modern.mjs", "types": "./dist/index.d.ts" }
+    "require": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.cjs"
+    },
+    "default": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.modern.mjs"
+    }
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.module.js",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "source": "src/index.ts",
   "exports": {
-    "require": "./dist/index.cjs",
-    "default": "./dist/index.modern.mjs"
+    "require": { "import": "./dist/index.cjs", "types": "./dist/index.d.ts" },
+    "default": { "import": "./dist/index.modern.mjs", "types": "./dist/index.d.ts" }
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.module.js",


### PR DESCRIPTION
> do not merge

Test to deploy the NPM package

testing https://github.com/cowprotocol/app-data/pull/79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package version to 2.5.2-rc.0.
	- Improved module exports to explicitly provide TypeScript type definitions for both CommonJS and ES module consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->