### PR TITLE
chore: small nit doc improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: 14
 
       - name: Cache Yarn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             node_modules

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
       - name: Cache Yarn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             node_modules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
           node-version: 14
 
       - name: Cache Yarn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             node_modules

--- a/src/api/fetchDocFromAppData.ts
+++ b/src/api/fetchDocFromAppData.ts
@@ -23,7 +23,7 @@ export async function fetchDocFromAppDataHex(
 /**
  * Fetches the document from IPFS using the appData hex
  *
- * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
+ * @deprecated Uses the legacy method of deriving the CID from the appData hex
  *
  * @param appDataHex
  * @param ipfsUri

--- a/src/api/fetchDocFromCid.ts
+++ b/src/api/fetchDocFromCid.ts
@@ -2,7 +2,7 @@ import { AnyAppDataDocVersion } from '../generatedTypes'
 import { DEFAULT_IPFS_READ_URI } from '../consts'
 
 /**
- * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
+ * Fetches the document from IPFS using the CID
  *
  * @param cid
  * @param ipfsUri

--- a/src/api/getAppDataInfo.ts
+++ b/src/api/getAppDataInfo.ts
@@ -7,32 +7,29 @@ import { appDataHexToCid } from './appDataHexToCid'
 import { validateAppDataDoc } from './validateAppDataDoc'
 
 /**
- * Calculates appDataHex without publishing file to IPFS
+ * Calculate the app-data information (cid, appDataHex, appDataContent).
  *
- * This method is intended to quickly generate the appDataHex independent
- * of IPFS upload/pinning
- *
- * @param appData JSON document which will be stringified in a deterministic way to calculate the IPFS hash
+ * - appDataContent is the exact string with the pre-image that gets hashed using keccak to get the appDataHex
+ * - appDataHex is the hex used for the bytes32 struct field appData in the CoW order
+ * - cid is the IPFS identifier of the appDataHex. If the document is in IPFS it can be found using this identifier.
  */
 export async function getAppDataInfo(appData: AnyAppDataDocVersion): Promise<AppDataInfo>
 
 /**
- * Calculates appDataHex without publishing file to IPFS
+ * Calculate the app-data information (cid, appDataHex, appDataContent).
  *
- * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
- *
- * This method is intended to quickly generate the appDataHex independent
- * of IPFS upload/pinning
- *
- * @param fullAppData JSON string with the full appData document
+ * - appDataContent is the exact string with the pre-image that gets hashed using keccak to get the appDataHex
+ * - appDataHex is the hex used for the bytes32 struct field appData in the CoW order
+ * - cid is the IPFS identifier of the appDataHex. If the document is in IPFS it can be found using this identifier.
  */
 export async function getAppDataInfo(fullAppData: string): Promise<AppDataInfo | undefined>
 
 /**
- * @deprecated AppData is not longer stored on IPFS nor it's derived from IPFS content hashes
+ * Calculate the app-data information (cid, appDataHex, appDataContent).
  *
- * @param appDataAux
- * @returns
+ * - appDataContent is the exact string with the pre-image that gets hashed using keccak to get the appDataHex
+ * - appDataHex is the hex used for the bytes32 struct field appData in the CoW order
+ * - cid is the IPFS identifier of the appDataHex. If the document is in IPFS it can be found using this identifier.
  */
 export async function getAppDataInfo(appDataAux: AnyAppDataDocVersion | string): Promise<AppDataInfo> {
   return _appDataToCidAux(appDataAux, _appDataToCid)


### PR DESCRIPTION
I was adapting CoW Swap to the new app-data changes and saw `getAppDataInfo` which is one important method in the metadata SDK, is deprecated.


I changed the docs to explain better what it returns.

<img width="718" alt="image" src="https://github.com/user-attachments/assets/95d6ab46-a443-46b3-9b6b-e22ad3b30e30" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved and clarified descriptions in user-facing documentation for several app data functions, including updates to deprecation notes and function purposes. No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->